### PR TITLE
allow unattended silent screenshot of given rect

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Takes file, stdin, or screencapture as input.
 > cd macOCR
 > swift build -c release
 > .build/release/ocr -h                                                                                      
-USAGE: ocr [--capture] [--stdin] [-i <i>]
+USAGE: ocr [--capture] [-r <r>] [--stdin] [-i <i>]
 
 OPTIONS:
   -c, --capture           Capture screenshot. 
+  -r <r>                  Rectangle to unattendedly capture (-r x,y,w,h), needs --capture.
   -s, --stdin             Read stdin binary data. 
   -i <i>                  Path to input image. 
   -h, --help              Show help information.

--- a/Sources/ocr/CLIArgs.swift
+++ b/Sources/ocr/CLIArgs.swift
@@ -7,12 +7,14 @@ struct CLIArgs {
         @Flag(name: [.customShort("c"), .long], help: "Capture screenshot.")
         var capture: Bool = false
 
+        @Option(name: [.customShort("r")], help: "Rectangle to unattendedly capture (-r x,y,w,h), needs --capture.")
+        var rectangle: String?
+
         @Flag(name: [.customShort("s"), .long], help: "Read stdin binary data.")
         var stdin: Bool = false
 
         @Option(name: [.customShort("i")], help: "Path to input image.", completion: CompletionKind.file(extensions: ["gif", "png", "jpg", "webp", "tiff"]))
         var input: String?
-
 
     }
 }

--- a/Sources/ocr/ScreenCapture.swift
+++ b/Sources/ocr/ScreenCapture.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-func captureRegion(destination: URL) -> URL {
+func captureRegion(destination: URL, rect: String?) -> URL {
     let destinationPath = destination.path as String
     
     let task = Process()
     task.launchPath = "/usr/sbin/screencapture"
-    task.arguments = ["-i", "-r", destinationPath]
+    task.arguments = rect != nil ? ["-R" + rect!, "-x", "-r", destinationPath] : ["-i", "-r", destinationPath]
     task.launch()
     task.waitUntilExit()
     


### PR DESCRIPTION
Fixes https://github.com/schappim/macOCR/issues/35

Allows to specify a rectangle section via args when capturing a screenshot, i.e. `-c -r 1000,1000,100,50` will snap a screenshot 100x50 at location 1000,1000 and perform its OCR operation on it.

The mode is designed for unattended script usage, thus `-x` is also passed to `screencapture` to disable any sound playing.